### PR TITLE
Fix Typo

### DIFF
--- a/src/components/FractalViewer/FractalViewer.jsx
+++ b/src/components/FractalViewer/FractalViewer.jsx
@@ -225,7 +225,7 @@ class FractalViewer extends React.Component {
       this.mouseY = e.pageY - this.height * this.position;
     } else {
       this.mouseX = e.pageX - this.width * this.position;
-      this.mouseY = e.page;
+      this.mouseY = e.pageY;
     }
     if (this.dragging) {
       this.deltaX += e.movementX;


### PR DESCRIPTION
Hot fix for a breaking bug which caused `this.mouseY` to be undefined when in landscape mode